### PR TITLE
chore: remove unnecessary ts-node dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "ts-node": "^10.9.2",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-dts": "catalog:",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "inversify": "^6.2.1",
-    "ts-node": "^10.9.2",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-dts": "catalog:",


### PR DESCRIPTION
## Summary

- Remove ts-node dependency from CLI and MCP server packages
- ts-node is not being used anywhere in the codebase 
- The project uses tsx for TypeScript execution instead

## Benefits

- Reduces bundle size and dependency count
- tsx provides better performance and hot-reload capabilities
- Cleaner package.json files

## Testing

- ✅ CLI commands still work (`pnpm pm --help`)
- ✅ MCP server still works (`pm-mcp-server --help`) 
- ✅ TypeScript compilation passes (`pnpm run typecheck`)
- ✅ Dependencies install correctly (`pnpm install`)

🤖 Generated with [Claude Code](https://claude.ai/code)